### PR TITLE
livecomp(server): increase resources for statefulset and add requests

### DIFF
--- a/apps/livecomp/server-statefulset.yaml
+++ b/apps/livecomp/server-statefulset.yaml
@@ -17,9 +17,12 @@ spec:
       - name: app
         image: ghcr.io/roboticsoutreach/livecomp-server:latest-1738893633 # {"$imagepolicy": "flux-system:livecomp-server"}
         resources:
+          requests:
+            memory: 500Mi
+            cpu: 200m
           limits:
-            memory: "1Gi"
-            cpu: "200m"
+            memory: 1Gi
+            cpu: 500m
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true


### PR DESCRIPTION
This PR increases the maximum CPU that the Livecomp server can use to 500m.

It also adds a requests block, which guarantees at all times that at a minimum, 200m CPU and 500Mi RAM are available. The pods can scale up if required.

Currently, only the limits block is added, which if increased on the current cluster setup would cause problematic resource contention and overcommit CPU on the node.